### PR TITLE
A new test case handling 304 response header growth

### DIFF
--- a/tests/accumulate-headers-after-304.js
+++ b/tests/accumulate-headers-after-304.js
@@ -229,7 +229,6 @@ export default class MyTest extends Test {
         const offset = 1 + (workerId - 1);
         assert(offset >= 0);
         assert(offset < this._workerListeningAddresses.length);
-        console.log("Adress: === " + this._workerListeningAddresses[offset].port + " " + offset + " " + this._workerListeningAddresses.length);
         return this._workerListeningAddresses[offset];
     }
 }

--- a/tests/accumulate-headers-after-304.js
+++ b/tests/accumulate-headers-after-304.js
@@ -73,11 +73,12 @@ export default class MyTest extends Test {
         });
 
         configGen.replyHeaderMaxSize(function *(cfg) {
+            // TODO: Justify or remove each size other than 64KB
             yield 8*1024;
             yield 32*1024;
-            yield 64*1024;
+            yield 64*1024; // Squid's default; String::SizeMax_ is 64*1024-1
             yield 128*1024;
-            yield 2048*1024;
+            yield 2*1024*1024;
         });
 
         return configGen.generateConfigurators();
@@ -95,7 +96,7 @@ export default class MyTest extends Test {
 
         // This header appears in the initially cached response.
         // This header does not appear in the updatingResponse.
-        // This header must upppear in the updatedResponse.
+        // This header must appear in the updatedResponse.
         const hitCheck = new Field(Http.DaftFieldName("Hit-Check"), Gadgets.UniqueId("check"));
 
         const updateHeaderName = Http.DaftFieldName("Update");
@@ -192,7 +193,10 @@ export default class MyTest extends Test {
                 const receivedResponse = testCase.client().transaction().response;
                 assert(receivedResponse.startLine.codeInteger() === 200);
                 assert(!receivedResponse.header.has(hitCheck.name));
+
                 // allow the server argent to stop and the transaction to finish
+                // XXX: The above motivation does not make sense because this
+                // code runs _after_ all transactions have finished.
                 testCase.server().keepListening('never');
             });
 

--- a/tests/accumulate-headers-after-304.js
+++ b/tests/accumulate-headers-after-304.js
@@ -198,6 +198,8 @@ export default class MyTest extends Test {
                 testCase.server().keepListening('never');
             });
 
+            this.dut.ignoreProblems(/Failed to update.*exceed/);
+
             let started = testCase.run();
             await testCase.server().transaction().sentEverything();
             // handle proxy's retry attempt (after discovering that it's got too large prefix)

--- a/tests/accumulate-headers-after-304.js
+++ b/tests/accumulate-headers-after-304.js
@@ -191,8 +191,7 @@ export default class MyTest extends Test {
                 testCase.client().expectStatusCode(200);
                 assert(!testCase.client().transaction().response.header.has(grownField.name));
             });
-            // TODO: testCase.addMissCheck() does not work because it looks at
-            // the first 304 (Not Modified) response, not the second 200 (OK).
+            testCase.addMissCheck();
 
             this.dut.ignoreProblems(/Failed to update.*exceed/);
 

--- a/tests/accumulate-headers-after-304.js
+++ b/tests/accumulate-headers-after-304.js
@@ -152,6 +152,11 @@ export default class MyTest extends Test {
                 assert.equal(receivedResponse.header.value(hitCheck.name), hitCheck.value, "preserved originally cached header field");
             });
             await testCase.run();
+
+            // need some time to update the cached entry for disk-only SMP configurations
+            // without it the initially cached entry may be returned
+            // TODO: a better way to achieve this?
+            await Gadgets.SleepMs(1000);
         }
 
         {

--- a/tests/accumulate-headers-after-304.js
+++ b/tests/accumulate-headers-after-304.js
@@ -11,11 +11,12 @@ import * as Config from "../src/misc/Config";
 import * as ConfigurationGenerator from "../src/test/ConfigGen";
 import * as FuzzyTime from "../src/misc/FuzzyTime";
 import * as Http from "../src/http/Gadgets";
-import assert from "assert";
 import Field from "../src/http/Field";
 import HttpTestCase from "../src/test/HttpCase";
 import Resource from "../src/anyp/Resource";
 import Test from "../src/overlord/Test";
+
+import assert from "assert";
 
 Config.Recognize([
     {

--- a/tests/accumulate-headers-after-304.js
+++ b/tests/accumulate-headers-after-304.js
@@ -117,6 +117,7 @@ export default class MyTest extends Test {
                 client.expectStatusCode(200);
             });
             await testCase.run();
+            await this.dut.finishCaching();
         }
 
         {
@@ -128,7 +129,6 @@ export default class MyTest extends Test {
                 client.expectStatusCode(304);
             });
             await testCase.run();
-            await this.dut.finishCaching();
         }
 
         let updatingResponse = null;

--- a/tests/accumulate-headers-after-304.js
+++ b/tests/accumulate-headers-after-304.js
@@ -184,28 +184,19 @@ export default class MyTest extends Test {
 
             testCase.server().response.startLine.code(304);
             testCase.server().response.header.add(grownField);
-            testCase.server().keepListening('always');
+            testCase.server().keepListening(true);
             testCase.server().serve(resource);
 
             testCase.check(() => {
                 testCase.client().expectStatusCode(200);
                 assert(!testCase.client().transaction().response.header.has(grownField.name));
-
-                // allow the server argent to stop and the transaction to finish
-                // XXX: The above motivation does not make sense because this
-                // code runs _after_ all transactions have finished.
-                testCase.server().keepListening('never');
             });
             // TODO: testCase.addMissCheck() does not work because it looks at
             // the first 304 (Not Modified) response, not the second 200 (OK).
 
             this.dut.ignoreProblems(/Failed to update.*exceed/);
 
-            const started = testCase.run();
-            await testCase.server().transaction().sentEverything();
-            // handle proxy's retry attempt (after discovering that it's got too large prefix)
-            testCase.server().resetTransaction();
-            await started;
+            await testCase.run();
         }
 
         AddressPool.ReleaseListeningAddress(resource.uri.address);

--- a/tests/accumulate-headers-after-304.js
+++ b/tests/accumulate-headers-after-304.js
@@ -1,0 +1,178 @@
+// Daft-based Squid Tests
+// Copyright (C) The Measurement Factory.
+// http://www.measurement-factory.com/
+
+// Tests whether an HTTP proxy does not allow to increase an HTTP response header
+// via 304 responses more than the specified limit.
+
+import HttpTestCase from "../src/test/HttpCase";
+import Field from "../src/http/Field";
+import Body from "../src/http/Body";
+import Resource from "../src/anyp/Resource";
+import * as ConfigurationGenerator from "../src/test/ConfigGen";
+import * as AddressPool from "../src/misc/AddressPool";
+import * as FuzzyTime from "../src/misc/FuzzyTime";
+import * as Gadgets from "../src/misc/Gadgets";
+import * as Config from "../src/misc/Config";
+import assert from "assert";
+import Test from "../src/overlord/Test";
+
+// TODO: make configurable
+const MaxHeaderSize = 65536;
+
+Config.Recognize([
+    {
+        option: "smp",
+        type: "Boolean",
+        default: "false",
+        description: "In this mode MISS, UPDATE and HIT requests will go to different proxy SMP workers",
+    },
+    {
+        option: "dut-cache",
+        type: "String",
+        enum: [ 'mem', 'disk', 'all' ],
+        description: "Turns on rock disk cache",
+    },
+]);
+
+export default class MyTest extends Test {
+
+    _configureDut(cfg) {
+        const memCache = Config.dutCache() === 'mem' || Config.dutCache() === 'all';
+        const diskCache = Config.dutCache() === 'disk' || Config.dutCache() === 'all';
+        cfg.memoryCaching(memCache || !Config.smp()); // always turn on memory cache in non-smp mode
+        cfg.diskCaching(diskCache && Config.smp()); // turn on rock only in smp mode
+
+        if (Config.smp()) {
+            cfg.workers(4);
+            cfg.dedicatedWorkerPorts(true);
+            this._workerListeningAddresses = cfg.workerListeningAddresses();
+        } 
+    }
+
+    static Configurators() {
+        const configGen = new ConfigurationGenerator.FlexibleConfigGen();
+
+        configGen.smp(function *(cfg) {
+            yield false;
+            yield true;
+        });
+
+        configGen.dutCache(function *(cfg) {
+            yield "mem";
+            if (cfg.smp()) {
+                yield "disk";
+                yield "all";
+            }
+        });
+        
+        return configGen.generateConfigurators();
+    }
+
+    async testOne(headerSize, updateSuccess) {
+
+        let resource = new Resource();
+        resource.uri.address = AddressPool.ReserveListeningAddress();
+        resource.modifiedAt(FuzzyTime.DistantPast());
+        resource.expireAt(FuzzyTime.Soon());
+        resource.body = new Body("z".repeat(64));
+        resource.finalize();
+
+        // This header appears in the initially cached response.
+        // This header does not appear in the updatingResponse.
+        // This header must upppear in the updatedResponse.
+        const hitCheck = new Field("X-Daft-Hit-Check", Gadgets.UniqueId("check"));
+
+        let updateField = new Field("X-Update-Header", Gadgets.UniqueId("update"));
+        updateField.finalize();
+        const updateHeaderLength = updateField.raw().length;
+        
+        {
+            let testCase = new HttpTestCase('forward a cachable response');
+            testCase.client().request.for(resource);
+            if (Config.smp())
+                testCase.client().nextHopAddress = this._workerListeningAddresses[1];
+            testCase.server().serve(resource);
+            let startLine = testCase.server().response.startLine;
+            startLine.finalize(); // 200 by default
+            const headerSeparator = 2; // "\r\n"
+            const finalPrefixSize = headerSize + startLine.raw().length + 2; // will become ofter receiving 304 updating response
+            const initialPrefixSize = finalPrefixSize - updateHeaderLength;
+            assert(initialPrefixSize <= MaxHeaderSize);
+            testCase.server().response.enforceMinimumPrefixSize(initialPrefixSize);
+            testCase.server().response.header.add(hitCheck);
+            await testCase.run();
+        }
+
+        {
+            let testCase = new HttpTestCase('respond with a 304 hit');
+            testCase.client().request.for(resource);
+            if (Config.smp())
+                testCase.client().nextHopAddress = this._workerListeningAddresses[1];
+            testCase.client().request.conditions({ ims: resource.notModifiedSince() });
+            testCase.client().checks.add((client) => {
+                client.expectStatusCode(304);
+            });
+            await testCase.run();
+        }
+
+        let updatingResponse = null;
+        {
+            let testCase = new HttpTestCase(`get a 304 that increases the cached header size on ${updateHeaderLength}`);
+
+            resource.modifyNow();
+            resource.expireAt(FuzzyTime.DistantFuture());
+
+            testCase.client().request.for(resource);
+            testCase.client().request.conditions({ ims: resource.modifiedSince() });
+            testCase.client().request.header.add("Cache-Control", "max-age=0");
+            if (Config.smp())
+                testCase.client().nextHopAddress = this._workerListeningAddresses[2];
+
+            testCase.server().response.header.add(updateField);
+            testCase.server().response.startLine.code(304);
+            testCase.server().serve(resource);
+            testCase.check(() => {
+                const receivedResponse = testCase.client().transaction().response;
+                const code = receivedResponse.startLine.codeInteger();
+                updatingResponse = testCase.server().transaction().response;
+                if (headerSize <= MaxHeaderSize) {
+                    assert.equal(updatingResponse.id(), receivedResponse.id(), "relayed X-Daft-Response-ID");
+                    assert.equal(code, 200);
+                } else {
+                    assert(code>=500);
+                }
+            });
+            await testCase.run();
+        }
+
+        {
+            let testCase = new HttpTestCase('hit updated headers');
+            testCase.client().request.for(resource);
+            if (Config.smp())
+                testCase.client().nextHopAddress = this._workerListeningAddresses[3];
+            testCase.check(() => {
+                let updatedResponse = testCase.client().transaction().response;
+                const code = updatedResponse.startLine.codeInteger();
+                if (headerSize <= MaxHeaderSize) {
+                    assert.equal(code, 200);
+                    assert.equal(updatingResponse.id(), updatedResponse.id(), "updated X-Daft-Response-ID");
+                    assert.equal(updatedResponse.header.values("Last-Modified"), resource.lastModificationTime.toUTCString(), "updated Last-Modified");
+                    assert.equal(updatedResponse.header.value(hitCheck.name), hitCheck.value, "preserved originally cached header field");
+                } else {
+                    assert(code>=500);
+                }
+            });
+            await testCase.run();
+        }
+
+        AddressPool.ReleaseListeningAddress(resource.uri.address);
+    }
+
+    async run(/*testRun*/) {
+        // TODO: test some other sizes?
+        await this.testOne(MaxHeaderSize);
+        await this.testOne(MaxHeaderSize+1);
+    }
+}
+

--- a/tests/accumulate-headers-after-304.js
+++ b/tests/accumulate-headers-after-304.js
@@ -19,9 +19,6 @@ import HttpTestCase from "../src/test/HttpCase";
 import Resource from "../src/anyp/Resource";
 import Test from "../src/overlord/Test";
 
-const DefaultPrefixSizeKB = 64;
-const DefaultPrefixSize = DefaultPrefixSizeKB*1024;
-
 Config.Recognize([
     {
         option: "workers",
@@ -36,7 +33,6 @@ Config.Recognize([
     {
         option: "max-prefix-size",
         type: "Number",
-        default: DefaultPrefixSize.toString(),
         description: "squid.conf::reply_header_max_size value (KB)",
     },
 ]);

--- a/tests/accumulate-headers-after-304.js
+++ b/tests/accumulate-headers-after-304.js
@@ -92,7 +92,7 @@ export default class MyTest extends Test {
         resource.expireAt(FuzzyTime.Soon());
         resource.finalize();
 
-        // single byte growth of this small field pushes Squid over the limit
+        // single byte growth of this small field pushes Squid over the prefix limit
         const fieldThatWillGrow = new Field(Http.DaftFieldName("Update"), 'x');
         const grownField = fieldThatWillGrow.clone();
         grownField.value += "y";
@@ -118,7 +118,7 @@ export default class MyTest extends Test {
         }
 
         {
-            const testCase = new HttpTestCase('verify that we cached the response with a smaller-than-allowed prefix');
+            const testCase = new HttpTestCase('verify that the proxy cached the response with a smaller-than-allowed prefix');
             testCase.client().request.for(resource);
             testCase.client().nextHopAddress = this._workerListeningAddressFor(2);
             testCase.client().request.conditions({ ims: resource.notModifiedSince() });
@@ -172,7 +172,7 @@ export default class MyTest extends Test {
         }
 
         {
-            const testCase = new HttpTestCase(`push prefix size beyond the ${this.prefixSizeMax()}-byte maximum`);
+            const testCase = new HttpTestCase(`attempt to push cached prefix size beyond the ${this.prefixSizeMax()}-byte maximum`);
 
             resource.modifyNow();
             resource.expireAt(FuzzyTime.DistantFuture());

--- a/tests/accumulate-headers-after-304.js
+++ b/tests/accumulate-headers-after-304.js
@@ -144,9 +144,9 @@ export default class MyTest extends Test {
             testCase.client().request.header.add("Cache-Control", "max-age=0");
             testCase.client().nextHopAddress = this._workerListeningAddressFor(3);
 
+            testCase.server().serve(resource);
             testCase.server().response.startLine.code(304);
             testCase.server().response.header.add(fieldThatWillGrow);
-            testCase.server().serve(resource);
 
             testCase.check(() => {
                 testCase.client().expectStatusCode(200);
@@ -184,10 +184,10 @@ export default class MyTest extends Test {
             testCase.client().request.header.add("Cache-Control", "max-age=0");
             testCase.client().nextHopAddress = this._workerListeningAddressFor(5);
 
+            testCase.server().serve(resource);
             testCase.server().response.startLine.code(304);
             testCase.server().response.header.add(grownField);
             testCase.server().keepListening(true);
-            testCase.server().serve(resource);
 
             testCase.check(() => {
                 testCase.client().expectStatusCode(200);

--- a/tests/accumulate-headers-after-304.js
+++ b/tests/accumulate-headers-after-304.js
@@ -23,10 +23,14 @@ const DefaultPrefixSize = DefaultPrefixSizeKB*1024;
 
 Config.Recognize([
     {
-        option: "smp",
+        option: "workers",
+        type: "Number",
+        description: "the number of Squid worker processes",
+    },
+    {
+        option: "poke-same-worker",
         type: "Boolean",
-        default: "false",
-        description: "In this mode MISS, UPDATE and HIT requests will go to different proxy SMP workers",
+        description: "send all test case requests to the same Squid worker process",
     },
     {
         option: "max-prefix-size",
@@ -34,42 +38,41 @@ Config.Recognize([
         default: DefaultPrefixSize.toString(),
         description: "maximum message body size (KB)",
     },
-
 ]);
 
 export default class MyTest extends Test {
 
     _configureDut(cfg) {
-        assert(!Config.dutDiskCache() || Config.smp());
         assert(Config.dutMemoryCache() || Config.dutDiskCache());
-        if (Config.smp()) {
-            cfg.workers(4);
-            cfg.dedicatedWorkerPorts(true);
-            this._workerListeningAddresses = cfg.workerListeningAddresses();
-        } 
-        cfg.custom(`reply_header_max_size ${Config.MaxPrefixSize} KB`);
+        cfg.workers(Config.workers());
+        cfg.dedicatedWorkerPorts(Config.workers() > 1);
+        this._workerListeningAddresses = cfg.workerListeningAddresses();
+        cfg.custom(`reply_header_max_size ${Config.maxPrefixSize()} KB`);
     }
 
     static Configurators() {
         const configGen = new ConfigurationGenerator.FlexibleConfigGen();
 
-        configGen.smp(function *(cfg) {
+        configGen.workers(function *() {
+            yield 1;
+            yield 5;
+        });
+
+        configGen.pokeSameWorker(function *(cfg) {
+            if (cfg.workers() > 1) // poking different workers requires multiple workers
+                yield false;
+            yield true;
+        });
+
+        configGen.dutMemoryCache(function *(cfg) {
             yield false;
             yield true;
         });
 
         configGen.dutDiskCache(function *(cfg) {
-            yield false;
-            if (cfg.smp()) {
-                yield true;
-            }
-        });
-
-        configGen.dutMemoryCache(function *(cfg) {
-            yield true;
-            if (cfg.dutDiskCache()) {
+            if (cfg.dutMemoryCache()) // do not end up with no caching at all
                 yield false;
-            }
+            yield true;
         });
 
         configGen.maxPrefixSize(function *(cfg) {
@@ -79,11 +82,11 @@ export default class MyTest extends Test {
             yield 128;
             yield 2048;
         });
-        
+
         return configGen.generateConfigurators();
     }
 
-    maxPrefixSize() { return Config.MaxPrefixSize * 1024; }
+    maxPrefixSize() { return Config.maxPrefixSize() * 1024; }
 
     async run(/*testRun*/) {
         let resource = new Resource();
@@ -101,13 +104,12 @@ export default class MyTest extends Test {
         let updateField = new Field(updateHeaderName, 'x');
         updateField.finalize();
         const updateHeaderLength = updateField.raw().length;
-        
+
         {
             const prefixSize = this.maxPrefixSize() - updateHeaderLength;
             let testCase = new HttpTestCase(`forward a cachable response with a prefix size less than the maximum allowed ${prefixSize}<${this.maxPrefixSize()}`);
             testCase.client().request.for(resource);
-            if (Config.smp())
-                testCase.client().nextHopAddress = this._workerListeningAddresses[1];
+            testCase.client().nextHopAddress = this._workerListeningAddressFor(1);
             testCase.server().serve(resource);
             testCase.server().response.enforceMinimumPrefixSize(prefixSize);
             testCase.server().response.header.add(hitCheck);
@@ -120,13 +122,13 @@ export default class MyTest extends Test {
         {
             let testCase = new HttpTestCase('respond with a 304 hit');
             testCase.client().request.for(resource);
-            if (Config.smp())
-                testCase.client().nextHopAddress = this._workerListeningAddresses[1];
+            testCase.client().nextHopAddress = this._workerListeningAddressFor(2);
             testCase.client().request.conditions({ ims: resource.notModifiedSince() });
             testCase.client().checks.add((client) => {
                 client.expectStatusCode(304);
             });
             await testCase.run();
+            await this.dut.finishCaching();
         }
 
         let updatingResponse = null;
@@ -139,8 +141,7 @@ export default class MyTest extends Test {
             testCase.client().request.for(resource);
             testCase.client().request.conditions({ ims: resource.modifiedSince() });
             testCase.client().request.header.add("Cache-Control", "max-age=0");
-            if (Config.smp())
-                testCase.client().nextHopAddress = this._workerListeningAddresses[2];
+            testCase.client().nextHopAddress = this._workerListeningAddressFor(3);
 
             testCase.server().response.header.add(updateField);
             testCase.server().response.startLine.code(304);
@@ -151,19 +152,18 @@ export default class MyTest extends Test {
                 assert(receivedResponse.startLine.codeInteger() === 200);
                 assert.equal(receivedResponse.header.value(hitCheck.name), hitCheck.value, "preserved originally cached header field");
             });
-            await testCase.run();
 
-            // need some time to update the cached entry for disk-only SMP configurations
-            // without it the initially cached entry may be returned
-            // TODO: a better way to achieve this?
-            await Gadgets.SleepMs(1000);
+            await testCase.run();
+            // XXX: Does not work when updating headers
+            // await this.dut.finishCaching();
         }
 
         {
             let testCase = new HttpTestCase(`hit the cached entry with the maximum allowed prefix: ${this.maxPrefixSize()} `);
             testCase.client().request.for(resource);
-            if (Config.smp())
-                testCase.client().nextHopAddress = this._workerListeningAddresses[3];
+            // TODO: should be step '4'. Temporarily set as the previous step to overcome
+            // the 'dut.finishCaching()' problem for updates
+            testCase.client().nextHopAddress = this._workerListeningAddressFor(3);
             testCase.check(() => {
                 let updatedResponse = testCase.client().transaction().response;
                 const code = updatedResponse.startLine.codeInteger();
@@ -183,8 +183,7 @@ export default class MyTest extends Test {
             testCase.client().request.for(resource);
             testCase.client().request.conditions({ ims: resource.modifiedSince() });
             testCase.client().request.header.add("Cache-Control", "max-age=0");
-            if (Config.smp())
-                testCase.client().nextHopAddress = this._workerListeningAddresses[2];
+            testCase.client().nextHopAddress = this._workerListeningAddressFor(5);
 
             testCase.server().response.header.addOverwrite(updateHeaderName, "xy");
 
@@ -207,6 +206,31 @@ export default class MyTest extends Test {
         }
 
         AddressPool.ReleaseListeningAddress(resource.uri.address);
+    }
+
+    // TODO: Move/Refactor into Proxy::workerForStep().primaryAddress(): The
+    // primary listening address of the round-robin selected worker. Here,
+    // "primary" means a worker-designated address (if it exists) or the
+    // general proxy listening address (otherwise).
+    _workerListeningAddressFor(stepId)
+    {
+        assert(stepId >= 1);
+
+        let workerId = 1;
+        if (!Config.pokeSameWorker()) {
+            // use workers in round-robin fashion, using the first worker for
+            // the first step; both worker and step IDs are 1-based
+            assert(Config.workers() > 0);
+            workerId = 1 + ((stepId-1) % Config.workers());
+        }
+
+        // The first this._workerListeningAddresses element is a well-known
+        // port address shared by all workers. We do not use it here.
+        const offset = 1 + (workerId - 1);
+        assert(offset >= 0);
+        assert(offset < this._workerListeningAddresses.length);
+        console.log("Adress: === " + this._workerListeningAddresses[offset].port + " " + offset + " " + this._workerListeningAddresses.length);
+        return this._workerListeningAddresses[offset];
     }
 }
 

--- a/tests/accumulate-headers-after-304.js
+++ b/tests/accumulate-headers-after-304.js
@@ -178,7 +178,7 @@ export default class MyTest extends Test {
             testCase.client().request.header.add("Cache-Control", "max-age=0");
             testCase.client().nextHopAddress = this._workerListeningAddressFor(5);
 
-            testCase.server().response.header.addOverwrite(updateField.name, updateField.value + "y");
+            testCase.server().response.header.add(updateField.name, updateField.value + "y");
 
             testCase.server().response.startLine.code(304);
             testCase.server().keepListening('always');

--- a/tests/accumulate-headers-after-304.js
+++ b/tests/accumulate-headers-after-304.js
@@ -11,6 +11,7 @@ import Body from "../src/http/Body";
 import Resource from "../src/anyp/Resource";
 import * as ConfigurationGenerator from "../src/test/ConfigGen";
 import * as AddressPool from "../src/misc/AddressPool";
+import * as Http from "../src/http/Gadgets";
 import * as FuzzyTime from "../src/misc/FuzzyTime";
 import * as Gadgets from "../src/misc/Gadgets";
 import * as Config from "../src/misc/Config";
@@ -75,6 +76,8 @@ export default class MyTest extends Test {
             yield 8;
             yield 32;
             yield 64;
+            yield 128;
+            yield 2048;
         });
         
         return configGen.generateConfigurators();
@@ -92,9 +95,9 @@ export default class MyTest extends Test {
         // This header appears in the initially cached response.
         // This header does not appear in the updatingResponse.
         // This header must upppear in the updatedResponse.
-        const hitCheck = new Field("X-Daft-Hit-Check", Gadgets.UniqueId("check"));
+        const hitCheck = new Field(Http.DaftFieldName("Hit-Check"), Gadgets.UniqueId("check"));
 
-        const updateHeaderName = "X-Update-Header";
+        const updateHeaderName = Http.DaftFieldName("Update");
         let updateField = new Field(updateHeaderName, 'x');
         updateField.finalize();
         const updateHeaderLength = updateField.raw().length;
@@ -186,6 +189,7 @@ export default class MyTest extends Test {
             testCase.check(() => {
                 const receivedResponse = testCase.client().transaction().response;
                 assert(receivedResponse.startLine.codeInteger() === 200);
+                assert(!receivedResponse.header.has(hitCheck.name));
                 // allow the server argent to stop and the transaction to finish
                 testCase.server().keepListening('never');
             });

--- a/tests/accumulate-headers-after-304.js
+++ b/tests/accumulate-headers-after-304.js
@@ -49,8 +49,8 @@ export default class MyTest extends Test {
         const configGen = new ConfigurationGenerator.FlexibleConfigGen();
 
         configGen.workers(function *() {
-            yield 1;
-            yield 5;
+            yield 1; // minimal working configuration
+            yield 5; // the number of test cases; see Config.pokeSameWorker()
         });
 
         configGen.pokeSameWorker(function *(cfg) {

--- a/tests/accumulate-headers-after-304.js
+++ b/tests/accumulate-headers-after-304.js
@@ -187,9 +187,12 @@ export default class MyTest extends Test {
             testCase.server().serve(resource);
             testCase.server().response.startLine.code(304);
             testCase.server().response.header.add(grownField);
+            // expect 2 transactions: revalidation and then unconditional GET
             testCase.server().keepListening(true);
 
             testCase.check(() => {
+                assert.strictEqual(testCase.server().transactionsFinished(), 2);
+
                 testCase.client().expectStatusCode(200);
                 assert(!testCase.client().transaction().response.header.has(grownField.name));
             });

--- a/tests/accumulate-headers-after-304.js
+++ b/tests/accumulate-headers-after-304.js
@@ -10,10 +10,8 @@ import * as AddressPool from "../src/misc/AddressPool";
 import * as Config from "../src/misc/Config";
 import * as ConfigurationGenerator from "../src/test/ConfigGen";
 import * as FuzzyTime from "../src/misc/FuzzyTime";
-import * as Gadgets from "../src/misc/Gadgets";
 import * as Http from "../src/http/Gadgets";
 import assert from "assert";
-import Body from "../src/http/Body";
 import Field from "../src/http/Field";
 import HttpTestCase from "../src/test/HttpCase";
 import Resource from "../src/anyp/Resource";
@@ -61,7 +59,7 @@ export default class MyTest extends Test {
             yield true;
         });
 
-        configGen.dutMemoryCache(function *(cfg) {
+        configGen.dutMemoryCache(function *() {
             yield false;
             yield true;
         });
@@ -72,7 +70,7 @@ export default class MyTest extends Test {
             yield true;
         });
 
-        configGen.replyHeaderMaxSize(function *(cfg) {
+        configGen.replyHeaderMaxSize(function *() {
             // TODO: Justify or remove each size other than 64KB
             yield 8*1024;
             yield 32*1024;

--- a/tests/proxy-collapsed-forwarding.js
+++ b/tests/proxy-collapsed-forwarding.js
@@ -160,8 +160,12 @@ export default class MyTest extends Test {
         missClient.request.for(resource);
         missClient.nextHopAddress = this._workerListeningAddresses[1];
 
-        if (expect503s)
-            testCase.addMissCheck(); // before we add 503-getting clients
+        if (expect503s) {
+            // testCase.addMissCheck() would have included 503-getting clients
+            missClient.checks.add(() => {
+                missClient.expectResponse(testCase.server().transaction().response);
+            });
+        }
 
         // add clients for each worker; they should all collapse on missClient
         for (let worker = 1; worker <= Config.Workers; ++worker) {

--- a/tests/proxy-update-headers-after-304.js
+++ b/tests/proxy-update-headers-after-304.js
@@ -4,16 +4,16 @@
 
 // Proxy MUST update previously cached headers on 304 responses.
 
-import HttpTestCase from "../src/test/HttpCase";
-import Field from "../src/http/Field";
-import Body from "../src/http/Body";
-import Resource from "../src/anyp/Resource";
 import * as AddressPool from "../src/misc/AddressPool";
+import * as Config from "../src/misc/Config";
 import * as FuzzyTime from "../src/misc/FuzzyTime";
 import * as Gadgets from "../src/misc/Gadgets";
-import * as Config from "../src/misc/Config";
-import assert from "assert";
+import Field from "../src/http/Field";
+import HttpTestCase from "../src/test/HttpCase";
+import Resource from "../src/anyp/Resource";
 import Test from "../src/overlord/Test";
+
+import assert from "assert";
 
 Config.Recognize([
     {

--- a/tests/proxy-update-headers-after-304.js
+++ b/tests/proxy-update-headers-after-304.js
@@ -55,10 +55,6 @@ export default class MyTest extends Test {
         // This header must appear in the updatedResponse.
         const hitCheck = new Field("X-Daft-Hit-Check", Gadgets.UniqueId("check"));
 
-        // This header starts small in the initially cached response
-        // but becomes large in the updatingResponse.
-        let growingHeader = new Field("X-Daft-Growing", "small");
-
         {
             let testCase = new HttpTestCase('forward a cachable response');
 
@@ -68,7 +64,6 @@ export default class MyTest extends Test {
             testCase.server().serve(resource);
             testCase.server().response.tag("first");
             testCase.server().response.header.add(hitCheck);
-            testCase.server().response.header.add(growingHeader);
 
             testCase.client().checks.add((client) => {
                 client.expectStatusCode(200);
@@ -99,8 +94,6 @@ export default class MyTest extends Test {
             resource.modifyNow();
             resource.expireAt(FuzzyTime.DistantFuture());
 
-            growingHeader.value = "la" + "A".repeat(100) + "rge";
-
             testCase.client().nextHopAddress = this._workerListeningAddresses[2];
             testCase.client().request.for(resource);
             testCase.client().request.conditions({ ims: resource.modifiedSince() });
@@ -109,7 +102,6 @@ export default class MyTest extends Test {
             testCase.server().serve(resource);
             testCase.server().response.tag("second");
             testCase.server().response.startLine.code(304);
-            testCase.server().response.header.add(growingHeader);
 
             testCase.check(() => {
                 testCase.client().expectStatusCode(200);

--- a/tests/upgrade-protocols.js
+++ b/tests/upgrade-protocols.js
@@ -429,12 +429,13 @@ export default class MyTest extends Test {
         if (cfg.upgradePossible())
             testCase.client().transaction().messageParser.assumeBodyPresentAndEndsAtEof("receiving post-101 bytes");
 
+        testCase.server().serve(resource);
         testCase.server().response.startLine.code(101);
         if (cfg.serverHeaders())
             testCase.server().response.header.addMany(...cfg.serverHeaders());
         testCase.server().response.header.add("Connection", "Upgrade");
         testCase.server().response.forceEof = true;
-        testCase.server().serve(resource);
+        testCase.server().response.body.forcePresence("faking post-101 response");
 
         testCase.check(() => {
                 const serverReceived = testCase.server().transaction().request.header.values("Upgrade");

--- a/tests/upgrade-protocols.js
+++ b/tests/upgrade-protocols.js
@@ -426,6 +426,8 @@ export default class MyTest extends Test {
         testCase.client().request.header.add(Http.DaftFieldName("Content-Length"), earlyClientBody.innedSize());
         testCase.client().request.header.prohibitNamed("Content-Length");
         testCase.client().request.header.prohibitNamed("Transfer-Encoding");
+        if (cfg.upgradePossible())
+            testCase.client().transaction().messageParser.assumeBodyPresentAndEndsAtEof("receiving post-101 bytes");
 
         testCase.server().response.startLine.code(101);
         if (cfg.serverHeaders())


### PR DESCRIPTION
Check that Squid does not allow to grow response
headers more than reply_header_max_size.